### PR TITLE
Add Laravel 13 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased](https://github.com/markwalet/laravel-testable-requests/compare/v0.4.1...master)
 
+### Added
+- Added support for Laravel 13
+
+### Changed
+- Raised the minimum supported PHP version to 8.1
+
 ## [v0.4.1 (2025-03-05)](https://github.com/markwalet/laravel-testable-requests/compare/v0.4.0...v0.4.1)
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         }
     },
     "require": {
-        "php": "^8.0",
-        "laravel/framework": "^10.0|^11.0|^12.0"
+        "php": "^8.1",
+        "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5|^11.0"


### PR DESCRIPTION
## Summary
- add Laravel 13 to the supported framework constraint
- raise the package minimum PHP version to 8.1 to match the supported Laravel range
- document the support change in the changelog

## Why
Laravel 13 support is exposed through Composer constraints in this package, so widening the framework version range and aligning the PHP floor is sufficient for consumers and package metadata.