### PR TITLE
Add package tests and CI workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,35 @@
+name: coverage
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    name: Coverage
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: dom, libxml, mbstring, zip, pcntl
+          coverage: xdebug
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:^13.0" "orchestra/testbench:11.*" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
+
+      - name: Calculate coverage statistics
+        run: vendor/bin/phpunit --coverage-clover clover.xml
+
+      - name: Send coverage statistics
+        uses: codecov/codecov-action@v5

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,17 +19,15 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: 8.4
           extensions: dom, libxml, mbstring, zip, pcntl
           coverage: xdebug
 
       - name: Install dependencies
-        run: |
-          composer require "laravel/framework:^13.0" "orchestra/testbench:11.*" --no-interaction --no-update
-          composer update --prefer-dist --no-interaction
+        run: composer update --prefer-dist --no-interaction
 
       - name: Calculate coverage statistics
-        run: vendor/bin/phpunit --coverage-clover clover.xml
+        run: vendor/bin/phpunit --coverage-clover 'clover.xml'
 
       - name: Send coverage statistics
         uses: codecov/codecov-action@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        laravel:
-          - '10'
-          - '11'
-          - '12'
-          - '13'
-        dependency-version:
-          - prefer-lowest
-          - prefer-latest
-    name: L${{ matrix.laravel }} - ${{ matrix['dependency-version'] }}
+        php: [ 8.2, 8.3, 8.4, 8.5 ]
+        illuminate: [ ^11.0, ^12.0, ^13.0 ]
+        stability: [ prefer-lowest, prefer-stable ]
+        include:
+          - illuminate: ^11.0
+            testbench: 9.*
+          - illuminate: ^12.0
+            testbench: 10.*
+          - illuminate: ^13.0
+            testbench: 11.*
+        exclude:
+          - php: 8.2
+            illuminate: ^13.0
+    name: P${{ matrix.php }} - I${{ matrix.illuminate }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
@@ -32,41 +37,17 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.laravel == '10' && '8.1' || matrix.laravel == '11' && '8.2' || matrix.laravel == '12' && '8.2' || '8.3' }}
+          php-version: ${{ matrix.php }}
           extensions: dom, libxml, mbstring, zip, pcntl
           coverage: none
 
       - name: Install dependencies
         run: |
-          case "${{ matrix.laravel }}" in
-            10)
-              laravel_constraint="^10.50"
-              testbench_constraint="8.*"
-              ;;
-            11)
-              laravel_constraint="^11.44"
-              testbench_constraint="9.*"
-              ;;
-            12)
-              laravel_constraint="^12.0"
-              testbench_constraint="10.*"
-              ;;
-            13)
-              laravel_constraint="^13.0"
-              testbench_constraint="11.*"
-              ;;
-          esac
-          composer require "laravel/framework:${laravel_constraint}" "orchestra/testbench:${testbench_constraint}" --no-interaction --no-update
-          flags="--prefer-dist --no-interaction"
-          if [ "${{ matrix['dependency-version'] }}" = "prefer-lowest" ]; then
-            flags="--prefer-lowest ${flags}"
-          else
-            flags="--prefer-stable ${flags}"
-          fi
-          composer update ${flags}
+          composer require "laravel/framework:${{ matrix.illuminate }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: composer test
+        run: vendor/bin/phpunit
 
   tests-required:
     name: Tests Required

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,84 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+          - '10'
+          - '11'
+          - '12'
+          - '13'
+        dependency-version:
+          - prefer-lowest
+          - prefer-latest
+    name: L${{ matrix.laravel }} - ${{ matrix['dependency-version'] }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel == '10' && '8.1' || matrix.laravel == '11' && '8.2' || matrix.laravel == '12' && '8.2' || '8.3' }}
+          extensions: dom, libxml, mbstring, zip, pcntl
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          case "${{ matrix.laravel }}" in
+            10)
+              laravel_constraint="^10.50"
+              testbench_constraint="8.*"
+              ;;
+            11)
+              laravel_constraint="^11.44"
+              testbench_constraint="9.*"
+              ;;
+            12)
+              laravel_constraint="^12.0"
+              testbench_constraint="10.*"
+              ;;
+            13)
+              laravel_constraint="^13.0"
+              testbench_constraint="11.*"
+              ;;
+          esac
+          composer require "laravel/framework:${laravel_constraint}" "orchestra/testbench:${testbench_constraint}" --no-interaction --no-update
+          flags="--prefer-dist --no-interaction"
+          if [ "${{ matrix['dependency-version'] }}" = "prefer-lowest" ]; then
+            flags="--prefer-lowest ${flags}"
+          else
+            flags="--prefer-stable ${flags}"
+          fi
+          composer update ${flags}
+
+      - name: Execute tests
+        run: composer test
+
+  tests-required:
+    name: Tests Required
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - tests
+
+    steps:
+      - name: Verify test matrix completed successfully
+        run: |
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "Test matrix result: ${{ needs.tests.result }}"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 /composer.lock
 composer.phar
 .phpunit.result.cache
+.phpunit.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased](https://github.com/markwalet/laravel-testable-requests/compare/v0.4.1...master)
 
+### Added
+- Added a PHPUnit and Orchestra Testbench test suite for package-level request validation helpers.
+- Added GitHub Actions workflows for the test matrix and coverage reporting.
+
+### Changed
+- Raised the minimum supported PHP version to 8.2.
+
+### Fixed
+- Fixed `assertNotAuthorized()` to call the unauthorized assertion instead of recursively calling itself.
+
+### Removed
+- Removed support for Laravel 10.
+
 ## [v0.5.0 (2026-03-24)](https://github.com/markwalet/laravel-testable-requests/compare/v0.4.1...v0.5.0)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ The documentation is still being worked on. For now, please look at how these cl
 - Improved type hinting
 - Added `defaultData()` method to the request
 - Added `assertFailsValidationFor()` method to the validation result.
+
+## Testing
+
+Run the package test suite with:
+
+```shell
+composer test
+```

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,17 @@
             "MarkWalet\\TestableRequests\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "MarkWalet\\TestableRequests\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "php": "^8.1",
         "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
+        "orchestra/testbench": "^8.37|^9.17|^10.11|^11.0",
         "phpunit/phpunit": "^10.5|^11.0"
     },
     "minimum-stability": "dev",
@@ -36,5 +42,8 @@
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true
+    },
+    "scripts": {
+        "test": "./vendor/bin/phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,11 @@
         }
     },
     "require": {
-        "php": "^8.1",
-        "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
+        "php": "^8.2",
+        "laravel/framework": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.37|^9.17|^10.11|^11.0",
+        "orchestra/testbench": "^9.17|^10.11|^11.0",
         "phpunit/phpunit": "^10.5|^11.0"
     },
     "minimum-stability": "dev",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,4 +10,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="Package">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -130,7 +130,7 @@ class TestFormRequest
      */
     public function assertNotAuthorized(): void
     {
-        $this->assertNotAuthorized();
+        $this->assertUnauthorized();
     }
 
     /**

--- a/tests/Fixtures/SampleFormRequest.php
+++ b/tests/Fixtures/SampleFormRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MarkWalet\TestableRequests\Tests\Fixtures;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SampleFormRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return (bool) $this->user()?->can_submit;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'min:3'],
+            'email' => ['required', 'email'],
+            'account' => ['required', 'in:'.$this->route('account')],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'title.required' => 'A title is required.',
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace MarkWalet\TestableRequests\Tests;
+
+use Illuminate\Contracts\Foundation\Application;
+use MarkWalet\TestableRequests\TestFormRequest;
+use MarkWalet\TestableRequests\ValidatesRequests;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+abstract class TestCase extends Orchestra
+{
+    protected function makeRequest(string $requestClass, array $headers = [], string $method = 'POST'): TestFormRequest
+    {
+        return new class($this) {
+            use ValidatesRequests;
+
+            public function __construct(private readonly Orchestra $testCase)
+            {
+                $this->app = $testCase->application();
+                $this->serverVariables = [];
+            }
+
+            public function make(string $requestClass, array $headers = [], string $method = 'POST'): TestFormRequest
+            {
+                return $this->createRequest($requestClass, $headers, $method);
+            }
+
+            protected function prepareUrlForRequest($uri): string
+            {
+                return $this->testCase->makeUrl($uri);
+            }
+
+            protected function prepareCookiesForRequest(): array
+            {
+                return [];
+            }
+
+            protected function transformHeadersToServerVars(array $headers): array
+            {
+                $server = [];
+
+                foreach ($headers as $key => $value) {
+                    $key = strtoupper(str_replace('-', '_', $key));
+
+                    if (! in_array($key, ['CONTENT_TYPE', 'REMOTE_ADDR'], true)) {
+                        $key = 'HTTP_'.$key;
+                    }
+
+                    $server[$key] = $value;
+                }
+
+                return $server;
+            }
+        }->make($requestClass, $headers, $method);
+    }
+
+    public function makeUrl(string $uri): string
+    {
+        return $uri;
+    }
+
+    public function application(): Application
+    {
+        return $this->app;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,12 +3,15 @@
 namespace MarkWalet\TestableRequests\Tests;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Testing\TestResponse;
 use MarkWalet\TestableRequests\TestFormRequest;
 use MarkWalet\TestableRequests\ValidatesRequests;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
 {
+    protected static ?TestResponse $latestResponse = null;
+
     protected function makeRequest(string $requestClass, array $headers = [], string $method = 'POST'): TestFormRequest
     {
         $requestFactory = new class($this) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,7 @@ abstract class TestCase extends Orchestra
 {
     protected function makeRequest(string $requestClass, array $headers = [], string $method = 'POST'): TestFormRequest
     {
-        return new class($this) {
+        $requestFactory = new class($this) {
             use ValidatesRequests;
 
             public function __construct(private readonly Orchestra $testCase)
@@ -51,7 +51,9 @@ abstract class TestCase extends Orchestra
 
                 return $server;
             }
-        }->make($requestClass, $headers, $method);
+        };
+
+        return $requestFactory->make($requestClass, $headers, $method);
     }
 
     public function makeUrl(string $uri): string

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
 {
-    protected static ?TestResponse $latestResponse = null;
+    public static ?TestResponse $latestResponse = null;
 
     protected function makeRequest(string $requestClass, array $headers = [], string $method = 'POST'): TestFormRequest
     {

--- a/tests/TestFormRequestTest.php
+++ b/tests/TestFormRequestTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace MarkWalet\TestableRequests\Tests;
+
+use Illuminate\Auth\GenericUser;
+use MarkWalet\TestableRequests\Tests\Fixtures\SampleFormRequest;
+
+class TestFormRequestTest extends TestCase
+{
+    public function test_it_validates_with_default_data_and_route_parameters(): void
+    {
+        $result = $this->makeRequest(SampleFormRequest::class)
+            ->withParam('account', 'acme')
+            ->defaultData([
+                'title' => 'Valid title',
+                'email' => 'mark@example.com',
+            ])
+            ->validate([
+                'account' => 'acme',
+            ]);
+
+        $result->assertPassesValidation();
+    }
+
+    public function test_it_reports_validation_failures_and_messages(): void
+    {
+        $result = $this->makeRequest(SampleFormRequest::class)
+            ->withParam('account', 'acme')
+            ->validate([
+                'email' => 'not-an-email',
+                'account' => 'other',
+            ]);
+
+        $result
+            ->assertFailsValidation([
+                'title' => 'required',
+                'email' => 'email',
+                'account' => 'in:acme',
+            ])
+            ->assertFailsValidationFor('title', 'required')
+            ->assertHasMessage('A title is required.', 'title');
+    }
+
+    public function test_it_asserts_authorization_for_a_user(): void
+    {
+        $request = $this->makeRequest(SampleFormRequest::class)
+            ->by(new GenericUser(['can_submit' => true]));
+
+        $request->assertAuthorized();
+    }
+
+    public function test_assert_not_authorized_alias_uses_unauthorized_assertion(): void
+    {
+        $request = $this->makeRequest(SampleFormRequest::class)
+            ->by(new GenericUser(['can_submit' => false]));
+
+        $request->assertNotAuthorized();
+    }
+}

--- a/tests/TestValidationResultTest.php
+++ b/tests/TestValidationResultTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MarkWalet\TestableRequests\Tests;
+
+use MarkWalet\TestableRequests\Tests\Fixtures\SampleFormRequest;
+
+class TestValidationResultTest extends TestCase
+{
+    public function test_it_can_assert_a_specific_field_passes_while_others_fail(): void
+    {
+        $result = $this->makeRequest(SampleFormRequest::class)
+            ->withParam('account', 'acme')
+            ->validate([
+                'title' => 'okay',
+                'email' => 'not-an-email',
+                'account' => 'acme',
+            ]);
+
+        $result->assertPassesValidationFor('title');
+    }
+}


### PR DESCRIPTION
## Summary
- add a PHPUnit + Orchestra Testbench package test setup and request validation coverage
- fix the recursive `assertNotAuthorized()` helper while adding authorization tests
- add GitHub Actions workflows for the test matrix and coverage reporting

## Why
This package had no repository-level test suite or CI coverage. These changes add a repeatable package testing setup and automate it across supported Laravel versions.