### PR TITLE
Add Pint and PHPStan QA

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,53 @@
+name: static-analysis
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    name: PHPStan
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
+
+  pint:
+    runs-on: ubuntu-latest
+
+    name: Pint
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added a PHPUnit and Orchestra Testbench test suite for package-level request validation helpers.
 - Added GitHub Actions workflows for the test matrix and coverage reporting.
+- Added Laravel Pint and Larastan to handle code quality assurance.
 
 ### Changed
 - Raised the minimum supported PHP version to 8.2.
@@ -12,6 +13,7 @@
 
 ### Fixed
 - Fixed `assertNotAuthorized()` to call the unauthorized assertion instead of recursively calling itself.
+- Fixed internal and test-suite typing issues so PHPStan passes at level 6.
 
 ### Removed
 - Removed support for Laravel 10.

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,8 @@
         "laravel/framework": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
+        "larastan/larastan": "^3.9",
+        "laravel/pint": "^1.29",
         "orchestra/testbench": "^9.17|^10.11|^11.0",
         "phpunit/phpunit": "^10.5|^11.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+    - vendor/nesbot/carbon/extension.neon
+
+parameters:
+    paths:
+        - src/
+        - tests/
+
+    level: 6

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,37 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "assign_null_coalescing_to_coalesce_equal": true,
+        "blank_line_before_statement": true,
+        "class_attributes_separation": {
+            "elements": {
+                "const": "none",
+                "method": "one",
+                "property": "one",
+                "trait_import": "none"
+            }
+        },
+        "fully_qualified_strict_types": {
+            "import_symbols": true,
+            "leading_backslash_in_global_namespace": false,
+            "phpdoc_tags": [
+                "method",
+                "param",
+                "return",
+                "throws",
+                "type",
+                "var"
+            ]
+        },
+        "global_namespace_import": true,
+        "phpdoc_separation": false,
+        "phpdoc_summary": true,
+        "phpdoc_align": {
+            "align": "left",
+            "spacing": {
+                "param": 1
+            }
+        },
+        "no_superfluous_phpdoc_tags": false
+    }
+}

--- a/pint.json
+++ b/pint.json
@@ -24,6 +24,12 @@
             ]
         },
         "global_namespace_import": true,
+        "nullable_type_declaration": {
+            "syntax": "union"
+        },
+        "nullable_type_declaration_for_default_null_value": {
+            "use_nullable_type_declaration": true
+        },
         "phpdoc_separation": false,
         "phpdoc_summary": true,
         "phpdoc_align": {

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -74,7 +74,7 @@ class TestFormRequest
      *
      * @param Authenticatable|null $user
      */
-    public function by(?Authenticatable $user = null): static
+    public function by(null|Authenticatable $user = null): static
     {
         $this->request->setUserResolver(fn () => $user);
 

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -2,12 +2,13 @@
 
 namespace MarkWalet\TestableRequests;
 
-use Closure;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
+use ReflectionMethod;
 use Symfony\Component\HttpFoundation\InputBag;
+
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertTrue;
 
@@ -47,17 +48,17 @@ class TestFormRequest
      * Validate the request with the given data.
      *
      * @param array<string, mixed> $data
-     * @return TestValidationResult
      */
     public function validate(array $data = []): TestValidationResult
     {
         $data = array_merge($this->defaultData, $data);
         $this->request->request = new InputBag($data);
 
+        $reflectionMethod = new ReflectionMethod($this->request, 'getValidatorInstance');
+        $reflectionMethod->setAccessible(true);
+
         /** @var Validator $validator */
-        $validator = Closure::fromCallable(function () {
-            return $this->getValidatorInstance();
-        })->call($this->request);
+        $validator = $reflectionMethod->invoke($this->request);
 
         try {
             $validator->validate();
@@ -72,11 +73,10 @@ class TestFormRequest
      * Execute the request for a given user.
      *
      * @param Authenticatable|null $user
-     * @return $this
      */
-    public function by(Authenticatable|null $user = null)
+    public function by(?Authenticatable $user = null): static
     {
-        $this->request->setUserResolver(fn() => $user);
+        $this->request->setUserResolver(fn () => $user);
 
         return $this;
     }
@@ -89,7 +89,7 @@ class TestFormRequest
      */
     public function withParams(array $params): static
     {
-        foreach($params as $param => $value) {
+        foreach ($params as $param => $value) {
             $this->withParam($param, $value);
         }
 
@@ -118,7 +118,7 @@ class TestFormRequest
     public function assertAuthorized(): void
     {
         assertTrue(
-            $this->bully(fn() => $this->passesAuthorization(), $this->request),
+            $this->passesAuthorization(),
             'The provided user is not authorized by this request'
         );
     }
@@ -141,13 +141,19 @@ class TestFormRequest
     public function assertUnauthorized(): void
     {
         assertFalse(
-            $this->bully(fn() => $this->passesAuthorization(), $this->request),
+            $this->passesAuthorization(),
             'The provided user is authorized by this request'
         );
     }
 
-    private function bully(Closure $elevatedFunction, object $targetObject)
+    private function passesAuthorization(): bool
     {
-        return Closure::fromCallable($elevatedFunction)->call($targetObject);
+        $reflectionMethod = new ReflectionMethod($this->request, 'passesAuthorization');
+        $reflectionMethod->setAccessible(true);
+
+        /** @var bool $authorized */
+        $authorized = $reflectionMethod->invoke($this->request);
+
+        return $authorized;
     }
 }

--- a/src/TestValidationResult.php
+++ b/src/TestValidationResult.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 use Stringable;
+
 use function PHPUnit\Framework\assertArrayHasKey;
 use function PHPUnit\Framework\assertArrayNotHasKey;
 use function PHPUnit\Framework\assertContains;
@@ -16,6 +17,7 @@ use function PHPUnit\Framework\assertTrue;
 class TestValidationResult
 {
     private Validator $validator;
+
     private ?ValidationException $failed;
 
     /**
@@ -24,7 +26,7 @@ class TestValidationResult
      * @param Validator $validator
      * @param ValidationException|null $failed
      */
-    public function __construct(Validator $validator, ValidationException|null $failed = null)
+    public function __construct(Validator $validator, ?ValidationException $failed = null)
     {
         $this->validator = $validator;
         $this->failed = $failed;
@@ -113,11 +115,10 @@ class TestValidationResult
     /**
      * Assert that the request contains a validation message.
      *
-     * @param $message
-     * @param $rule
-     * @return $this
+     * @param string $message
+     * @param string|null $rule
      */
-    public function assertHasMessage($message, $rule = null): static
+    public function assertHasMessage(string $message, ?string $rule = null): static
     {
         $validationMessages = $this->getValidationMessages($rule);
         assertContains($message, $validationMessages,
@@ -132,35 +133,45 @@ class TestValidationResult
     /**
      * Get a list of all rules that failed.
      *
-     * @return array
+     * @return array<string, list<string>>
      */
     public function getFailedRules(): array
     {
-        if (!$this->failed) {
+        if (! $this->failed) {
             return [];
         }
 
-        return collect($this->validator->failed())
-            ->map(function ($details) {
-                return collect($details)->map(function ($constraints, $rule) {
-                    // TODO: Separate logic out to own class.
-                    $rule = class_exists($rule) && class_implements($rule, ValidationRule::class) ? $rule : Str::snake($rule);
+        $failedRules = [];
 
-                    return (count($constraints))
-                        ? $rule.':'.implode(',', $constraints)
-                        : $rule;
-                })->values()->toArray();
-            })
-            ->toArray();
+        foreach ($this->validator->failed() as $field => $details) {
+            $fieldRules = [];
+
+            foreach ($details as $rule => $constraints) {
+                $implementedInterfaces = class_exists($rule) ? class_implements($rule) ?: [] : [];
+
+                // TODO: Separate logic out to own class.
+                $normalizedRule = in_array(ValidationRule::class, $implementedInterfaces, true)
+                    ? $rule
+                    : Str::snake($rule);
+
+                $fieldRules[] = count($constraints) > 0
+                    ? $normalizedRule.':'.implode(',', $constraints)
+                    : $normalizedRule;
+            }
+
+            $failedRules[$field] = $fieldRules;
+        }
+
+        return $failedRules;
     }
 
     /**
      * Get a list of validation messages from the request.
      *
-     * @param $rule
+     * @param string|null $rule
      * @return array<int, string>
      */
-    private function getValidationMessages($rule = null): array
+    private function getValidationMessages(?string $rule = null): array
     {
         $messages = $this->validator->messages()->getMessages();
         if ($rule) {

--- a/src/TestValidationResult.php
+++ b/src/TestValidationResult.php
@@ -18,7 +18,7 @@ class TestValidationResult
 {
     private Validator $validator;
 
-    private ?ValidationException $failed;
+    private null|ValidationException $failed;
 
     /**
      * TestValidationResult constructor.
@@ -26,7 +26,7 @@ class TestValidationResult
      * @param Validator $validator
      * @param ValidationException|null $failed
      */
-    public function __construct(Validator $validator, ?ValidationException $failed = null)
+    public function __construct(Validator $validator, null|ValidationException $failed = null)
     {
         $this->validator = $validator;
         $this->failed = $failed;
@@ -118,7 +118,7 @@ class TestValidationResult
      * @param string $message
      * @param string|null $rule
      */
-    public function assertHasMessage(string $message, ?string $rule = null): static
+    public function assertHasMessage(string $message, null|string $rule = null): static
     {
         $validationMessages = $this->getValidationMessages($rule);
         assertContains($message, $validationMessages,
@@ -171,7 +171,7 @@ class TestValidationResult
      * @param string|null $rule
      * @return array<int, string>
      */
-    private function getValidationMessages(?string $rule = null): array
+    private function getValidationMessages(null|string $rule = null): array
     {
         $messages = $this->validator->messages()->getMessages();
         if ($rule) {

--- a/src/ValidatesRequests.php
+++ b/src/ValidatesRequests.php
@@ -2,6 +2,7 @@
 
 namespace MarkWalet\TestableRequests;
 
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
@@ -10,30 +11,34 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 trait ValidatesRequests
 {
     /**
-     * @param string $requestClass
-     * @param array $headers
-     * @param string $method
-     * @return TestFormRequest
+     * @param class-string<FormRequest> $requestClass
+     * @param array<string, string> $headers
      */
     protected function createRequest(string $requestClass, array $headers = [], string $method = 'POST'): TestFormRequest
     {
+        /** @var Application $app */
+        $app = $this->app;
+
+        /** @var array<string, string> $serverVariables */
+        $serverVariables = $this->serverVariables;
+
         $symfonyRequest = SymfonyRequest::create(
             $this->prepareUrlForRequest('/test/route'),
             $method,
             [],
             $this->prepareCookiesForRequest(),
             [],
-            array_replace($this->serverVariables, $this->transformHeadersToServerVars($headers))
+            array_replace($serverVariables, $this->transformHeadersToServerVars($headers))
         );
 
         $formRequest = FormRequest::createFrom(
             Request::createFromBase($symfonyRequest),
             new $requestClass
-        )->setContainer($this->app);
+        )->setContainer($app);
 
-        $route = new Route('POST', '/test/route', fn() => null);
+        $route = new Route('POST', '/test/route', fn () => null);
         $route->parameters = [];
-        $formRequest->setRouteResolver(fn() => $route);
+        $formRequest->setRouteResolver(fn () => $route);
 
         return new TestFormRequest($formRequest);
     }

--- a/tests/Fixtures/SampleFormRequest.php
+++ b/tests/Fixtures/SampleFormRequest.php
@@ -8,9 +8,12 @@ class SampleFormRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return (bool) $this->user()?->can_submit;
+        return (bool) data_get($this->user(), 'can_submit');
     }
 
+    /**
+     * @return array<string, list<string>>
+     */
     public function rules(): array
     {
         return [
@@ -20,6 +23,9 @@ class SampleFormRequest extends FormRequest
         ];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function messages(): array
     {
         return [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,42 +2,71 @@
 
 namespace MarkWalet\TestableRequests\Tests;
 
+use Closure;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Testing\TestResponse;
 use MarkWalet\TestableRequests\TestFormRequest;
 use MarkWalet\TestableRequests\ValidatesRequests;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Symfony\Component\HttpFoundation\Response;
 
 abstract class TestCase extends Orchestra
 {
+    /** @var TestResponse<Response>|null */
     public static ?TestResponse $latestResponse = null;
 
+    /**
+     * @param class-string<FormRequest> $requestClass
+     * @param array<string, string> $headers
+     */
     protected function makeRequest(string $requestClass, array $headers = [], string $method = 'POST'): TestFormRequest
     {
-        $requestFactory = new class($this) {
+        $requestFactory = new class($this->app, $this->makeUrl(...))
+        {
             use ValidatesRequests;
 
-            public function __construct(private readonly Orchestra $testCase)
+            protected Application $app;
+
+            /** @var array<string, string> */
+            protected array $serverVariables;
+
+            /** @var Closure(string): string */
+            private readonly Closure $urlBuilder;
+
+            public function __construct(Application $app, Closure $urlBuilder)
             {
-                $this->app = $testCase->application();
+                $this->app = $app;
                 $this->serverVariables = [];
+                $this->urlBuilder = $urlBuilder;
             }
 
+            /**
+             * @param class-string<FormRequest> $requestClass
+             * @param array<string, string> $headers
+             */
             public function make(string $requestClass, array $headers = [], string $method = 'POST'): TestFormRequest
             {
                 return $this->createRequest($requestClass, $headers, $method);
             }
 
-            protected function prepareUrlForRequest($uri): string
+            protected function prepareUrlForRequest(string $uri): string
             {
-                return $this->testCase->makeUrl($uri);
+                return ($this->urlBuilder)($uri);
             }
 
+            /**
+             * @return array<string, string>
+             */
             protected function prepareCookiesForRequest(): array
             {
                 return [];
             }
 
+            /**
+             * @param array<string, string> $headers
+             * @return array<string, string>
+             */
             protected function transformHeadersToServerVars(array $headers): array
             {
                 $server = [];
@@ -62,10 +91,5 @@ abstract class TestCase extends Orchestra
     public function makeUrl(string $uri): string
     {
         return $uri;
-    }
-
-    public function application(): Application
-    {
-        return $this->app;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
 abstract class TestCase extends Orchestra
 {
     /** @var TestResponse<Response>|null */
-    public static ?TestResponse $latestResponse = null;
+    public static null|TestResponse $latestResponse = null;
 
     /**
      * @param class-string<FormRequest> $requestClass


### PR DESCRIPTION
## Summary
- add Laravel Pint and Larastan for repository QA
- add a static-analysis GitHub Actions workflow for Pint and PHPStan
- fix source and test typing issues so PHPStan level 6 passes

## Why
This brings formatting and static analysis into CI so QA runs consistently and catches issues earlier.