### PR TITLE
Fix Enum rule validation detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Renamed references to old `master` default branch.
 
+### Fixed
+- Fixed `assertFailsValidationFor()` to properly detect `Illuminate\Validation\Rules\Enum` and other rule classes implementing the `Rule` interface.
+
 ## [v0.6.0 (2026-03-30)](https://github.com/markwalet/laravel-testable-requests/compare/v0.5.0...v0.6.0)
 
 ### Added

--- a/src/TestValidationResult.php
+++ b/src/TestValidationResult.php
@@ -2,6 +2,7 @@
 
 namespace MarkWalet\TestableRequests;
 
+use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -150,7 +151,8 @@ class TestValidationResult
                 $implementedInterfaces = class_exists($rule) ? class_implements($rule) ?: [] : [];
 
                 // TODO: Separate logic out to own class.
-                $normalizedRule = in_array(ValidationRule::class, $implementedInterfaces, true)
+                $isCustomRule = array_intersect([ValidationRule::class, Rule::class], $implementedInterfaces) !== [];
+                $normalizedRule = $isCustomRule
                     ? $rule
                     : Str::snake($rule);
 


### PR DESCRIPTION
## Summary
Fixes `assertFailsValidationFor()` failing to properly detect `Illuminate\Validation\Rules\Enum` and other rule classes implementing the older `Rule` interface.

The issue was in `getFailedRules()` which checks if a rule class implements `ValidationRule` to determine whether to keep the FQCN or snake_case the rule name. However, `Illuminate\Validation\Rules\Enum` implements the older `Illuminate\Contracts\Validation\Rule` interface, not `ValidationRule`, causing it to be incorrectly snake_cased to `"illuminate_validation_rules_enum"`.

The fix checks for both interfaces when determining if a class is a custom rule.

## Test plan
- All existing tests pass
- PHPStan analysis passes at level 6